### PR TITLE
refactor: migrate workflow config to claude_args and add turbopack root

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,27 +45,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          custom_instructions: |
-            The project is already set up with all dependencides installed. the server is already running at localhost:3000. Logs from it are being written to logs.txt. If needed, you can query the db with `sqlite3` cli. If needed use mcp_playwright set of tools to launch a brower and interact with the app.
-
-          mcp_config: |
-            {
-              "mcpServers": {
-                "playwright": {
-                  "command": "npx",
-                  "args": [
-                    "@playwright/mcp@latest",
-                    "--allowed-origins",
-                    "localhost:3000; cdn.tailwindcss.com;esm.sh"
-                  ]
-                }
-              }
-            }
-
-          allowed_tools: "Bash(npm:*),Bash:(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,..."
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: |
+            --system-prompt "The project is already set up with all dependencies installed. The server is already running at localhost:3000. Logs from it are being written to logs.txt. If needed, you can query the db with `sqlite3` cli. If needed use mcp_playwright set of tools to launch a browser and interact with the app."
+            --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["@playwright/mcp@latest","--allowed-origins","localhost:3000; cdn.tailwindcss.com;esm.sh"]}}}'
+            --allowedTools "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,..."
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  turbopack: {
+    root: __dirname,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Replace separate `custom_instructions`, `mcp_config`, and `allowed_tools` fields with unified `claude_args` in the Claude workflow
- Fix typos in the instruction text
- Fix `Bash` tool format (was `Bash:(sqlite3:*)`, now `Bash(sqlite3:*)`)
- Add `turbopack.root` config to `next.config.ts`

## Test plan
- [ ] Verify GitHub Actions workflow triggers correctly on issues/PRs
- [ ] Confirm `claude_args` flags are valid for the claude-code-action version in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)